### PR TITLE
feat(mobile): improve mobile UX (tap targets, responsive layouts, reset zoom)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -111,6 +111,8 @@
     const collapseBtn = document.getElementById("btn-collapse-all");
     if (expandBtn) expandBtn.addEventListener("click", expandAll);
     if (collapseBtn) collapseBtn.addEventListener("click", collapseAll);
+    const resetZoomBtn = document.getElementById("btn-reset-zoom");
+    if (resetZoomBtn) resetZoomBtn.addEventListener("click", resetZoom);
   }
 
   function processData() {
@@ -172,6 +174,12 @@
       .scaleExtent([0.1, 3])
       .on("zoom", (event) => state.d3.g.attr("transform", event.transform));
     state.d3.svg.call(state.d3.zoom);
+  }
+
+  function resetZoom() {
+    const { width, height } = DOM.treeView.getBoundingClientRect();
+    const transform = d3.zoomIdentity.translate(80, 0);
+    state.d3.svg.transition().duration(500).call(state.d3.zoom.transform, transform);
   }
 
   function collapse(d) {

--- a/public/index.html
+++ b/public/index.html
@@ -174,15 +174,17 @@
       }
 
       .view-btn {
-        padding: 0.5rem 0.75rem;
+        padding: 0.75rem 1rem;
         background: transparent;
         border: none;
         color: var(--text-secondary);
         cursor: pointer;
         border-radius: 15px;
         transition: all 0.3s ease;
-        font-size: 0.85rem;
+        font-size: 0.95rem;
         white-space: nowrap;
+        min-height: 44px;
+        min-width: 44px;
       }
       .view-btn.active {
         background: var(--accent-gradient);
@@ -289,8 +291,17 @@
 
       .cards-view {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
         gap: 1rem;
+      }
+
+      @media (max-width: 480px) {
+        .stats-bar {
+          grid-template-columns: 1fr;
+        }
+        .controls { padding: 0.75rem; }
+        .content { height: calc(100vh - 220px); }
+        .division-card { padding: 1rem; }
       }
       .division-card {
         background: linear-gradient(135deg, var(--bg-interactive), rgba(16, 33, 62, 0.3));
@@ -492,6 +503,9 @@
 
     <div class="content" role="main" aria-labelledby="pageHeading">
       <div id="treeView" class="tree-view" role="tabpanel" aria-labelledby="btn-tree">
+        <div class="controls-row" style="justify-content:flex-end;margin-bottom:0.5rem">
+          <button id="btn-reset-zoom" class="view-btn">Restablecer zoom</button>
+        </div>
         <svg id="treeSvg" role="img" aria-label="Árbol de ocupaciones"></svg>
       </div>
       <div id="tableView" class="table-view hidden" role="tabpanel" aria-labelledby="btn-table">


### PR DESCRIPTION
## Summary
- Increase tap target sizes and font for controls
- Make stats bar 1-column and cards denser on small screens
- Add "Restablecer zoom" control for tree view

## Test plan
- On small screens (<480px), verify layout adjustments
- Ensure reset zoom returns to initial view

💘 Generated with Crush