### PR TITLE
Neobrutalism theme: tokens, toggle, and base styles

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,12 +82,12 @@ Components to update
 
 Implementation steps
 
-1) Add CSS tokens and neobrutal class names; keep old vars for fallback
-2) Replace gradients/shadows with solid fills and borders
-3) Update tree node styles and link stroke widths
-4) Tighten focus states and keyboard outlines
-5) Add reduced-motion support
-6) Verify a11y and color-contrast (axe, Lighthouse)
+1. Add CSS tokens and neobrutal class names; keep old vars for fallback
+2. Replace gradients/shadows with solid fills and borders
+3. Update tree node styles and link stroke widths
+4. Tighten focus states and keyboard outlines
+5. Add reduced-motion support
+6. Verify a11y and color-contrast (axe, Lighthouse)
 
 Rollout
 

--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@
     <div class="header" role="banner">
       <h1 id="pageHeading">SINCO 2019 - Sistema Nacional de Clasificación de Ocupaciones</h1>
       <div class="controls-row" style="justify-content: flex-end; margin-bottom: 0.5rem">
-        <div style="display:flex; gap:.5rem; align-items:center">
+        <div style="display: flex; gap: 0.5rem; align-items: center">
           <button
             id="btn-toggle-stats"
             class="view-btn"

--- a/public/index.html
+++ b/public/index.html
@@ -110,14 +110,17 @@
     <div class="header" role="banner">
       <h1 id="pageHeading">SINCO 2019 - Sistema Nacional de Clasificación de Ocupaciones</h1>
       <div class="controls-row" style="justify-content: flex-end; margin-bottom: 0.5rem">
-        <button
-          id="btn-toggle-stats"
-          class="view-btn"
-          aria-expanded="true"
-          aria-controls="statsBar"
-        >
-          Ocultar métricas
-        </button>
+        <div style="display:flex; gap:.5rem; align-items:center">
+          <button
+            id="btn-toggle-stats"
+            class="view-btn"
+            aria-expanded="true"
+            aria-controls="statsBar"
+          >
+            Ocultar métricas
+          </button>
+          <button id="btn-theme-neo" class="view-btn" aria-pressed="false">Neo</button>
+        </div>
       </div>
       <div class="stats-bar" id="statsBar">
         <div class="stat-item">

--- a/src/app.js
+++ b/src/app.js
@@ -105,6 +105,12 @@ import * as d3 from "d3";
     if (collapseBtn) collapseBtn.addEventListener("click", collapseAll);
     const resetZoomBtn = document.getElementById("btn-reset-zoom");
     if (resetZoomBtn) resetZoomBtn.addEventListener("click", resetZoom);
+    const neoBtn = document.getElementById("btn-theme-neo");
+    if (neoBtn) neoBtn.addEventListener("click", () => {
+      document.body.classList.toggle("theme-neo");
+      const pressed = document.body.classList.contains("theme-neo");
+      neoBtn.setAttribute("aria-pressed", pressed ? "true" : "false");
+    });
   }
   function processData() {
     state.allNodes = state.rootNode.descendants();

--- a/src/app.js
+++ b/src/app.js
@@ -106,11 +106,13 @@ import * as d3 from "d3";
     const resetZoomBtn = document.getElementById("btn-reset-zoom");
     if (resetZoomBtn) resetZoomBtn.addEventListener("click", resetZoom);
     const neoBtn = document.getElementById("btn-theme-neo");
-    if (neoBtn) neoBtn.addEventListener("click", () => {
-      document.body.classList.toggle("theme-neo");
-      const pressed = document.body.classList.contains("theme-neo");
-      neoBtn.setAttribute("aria-pressed", pressed ? "true" : "false");
-    });
+    if (neoBtn) {
+      neoBtn.addEventListener("click", () => {
+        document.body.classList.toggle("theme-neo");
+        const pressed = document.body.classList.contains("theme-neo");
+        neoBtn.setAttribute("aria-pressed", pressed ? "true" : "false");
+      });
+    }
   }
   function processData() {
     state.allNodes = state.rootNode.descendants();
@@ -397,7 +399,8 @@ import * as d3 from "d3";
       card.className = "division-card";
       card.dataset.code = division.data.code;
       const code = division.data.code;
-      const count = state.divisionLeafCounts?.get(code) ?? state.leafCountByDivision?.get(code) ?? 0;
+      const count =
+        state.divisionLeafCounts?.get(code) ?? state.leafCountByDivision?.get(code) ?? 0;
       const totalEmployees = state.divisionEmployeeTotals?.get(code) ?? 0;
       card.innerHTML = `
               <div class="division-header">

--- a/src/style.css
+++ b/src/style.css
@@ -18,6 +18,21 @@
   --warning-gradient: linear-gradient(135deg, #ffaa00, #ff8800);
   --danger-gradient: linear-gradient(135deg, #ff4466, #ff2244);
 }
+/* Neobrutal theme tokens */
+.theme-neo {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f7f7f7;
+  --bg-tertiary: #f2f2f2;
+  --bg-interactive: #f2f2f2;
+  --text-primary: #111111;
+  --text-secondary: #333333;
+  --accent-primary: #111111;
+  --accent-secondary: #00d4ff;
+  --accent-gradient: none;
+  --shadow-color-light: transparent;
+  --shadow-color-dark: transparent;
+  --border-color: #111111;
+}
 *,
 *::before,
 *::after {
@@ -36,22 +51,17 @@ body {
   display: none !important;
 }
 .header {
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
+  background: var(--bg-secondary);
   padding: 1rem;
-  box-shadow: 0 4px 20px var(--shadow-color-dark);
+  border-bottom: 3px solid var(--border-color);
   position: sticky;
   top: 0;
   z-index: 1000;
 }
 .header h1 {
   font-size: 1.5rem;
-  background: var(--accent-gradient);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  text-fill-color: transparent;
+  color: var(--text-primary);
   margin-bottom: 1rem;
-  animation: glow 2s ease-in-out infinite alternate;
   text-align: center;
 }
 @keyframes glow {
@@ -133,27 +143,30 @@ body {
 .view-toggle {
   display: flex;
   gap: 0.25rem;
-  background: rgba(255, 255, 255, 0.05);
+  background: transparent;
   padding: 0.25rem;
-  border-radius: 20px;
 }
 .view-btn {
-  padding: 0.75rem 1rem;
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem;
+  background: #fff0;
+  border: 3px solid var(--border-color);
+  color: var(--text-primary);
   cursor: pointer;
-  border-radius: 15px;
-  transition: all 0.3s ease;
+  border-radius: 0;
+  transition: background-color 0.15s ease;
   font-size: 0.95rem;
   white-space: nowrap;
   min-height: 44px;
   min-width: 44px;
 }
 .view-btn.active {
-  background: var(--accent-gradient);
-  color: #fff;
-  box-shadow: 0 4px 15px var(--shadow-color-light);
+  background: var(--accent-secondary);
+  border-color: var(--text-primary);
+  color: #000;
+}
+.view-btn:focus-visible {
+  outline: 3px solid var(--text-primary);
+  outline-offset: 2px;
 }
 .content {
   height: calc(100vh - 210px);
@@ -172,8 +185,8 @@ body {
 .node circle {
   fill: var(--bg-tertiary);
   stroke: var(--accent-primary);
-  stroke-width: 2px;
-  transition: all 0.3s ease;
+  stroke-width: 3px;
+  transition: none;
 }
 .node:hover circle,
 .node.highlight circle {
@@ -268,17 +281,15 @@ tr:hover {
   }
 }
 .division-card {
-  background: linear-gradient(135deg, var(--bg-interactive), rgba(16, 33, 62, 0.3));
-  border: 2px solid var(--border-color);
-  border-radius: 15px;
-  padding: 1.5rem;
-  transition: all 0.3s ease;
+  background: var(--bg-tertiary);
+  border: 3px solid var(--border-color);
+  border-radius: 0;
+  padding: 1rem;
+  transition: background-color 0.15s ease;
   cursor: pointer;
 }
 .division-card:hover {
-  transform: translateY(-5px);
-  border-color: var(--accent-primary);
-  box-shadow: 0 4px 30px var(--shadow-color-light);
+  background: var(--bg-secondary);
 }
 .division-header {
   display: flex;
@@ -293,11 +304,13 @@ tr:hover {
   color: var(--accent-primary);
 }
 .occupation-count {
-  background: rgba(0, 212, 255, 0.2);
-  padding: 0.25rem 0.75rem;
-  border-radius: 15px;
+  background: var(--muted, #eaeaea);
+  padding: 0.25rem 0.5rem;
+  border: 3px solid var(--border-color);
+  border-radius: 0;
   font-size: 0.85rem;
   white-space: nowrap;
+  color: var(--text-primary);
 }
 .tooltip {
   position: fixed;

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -4,29 +4,31 @@ const baseURL = "http://localhost:5173";
 
 test("cards show non-zero counts", async ({ page }) => {
   await page.goto(baseURL + "/public/index.html");
-  await page.click('#btn-cards');
-  await page.waitForSelector('#cardsView:not(.hidden)');
-  const card = page.locator('.division-card').first();
+  await page.click("#btn-cards");
+  await page.waitForSelector("#cardsView:not(.hidden)");
+  const card = page.locator(".division-card").first();
   await expect(card).toBeVisible();
   const text = await card.textContent();
   const m = text?.match(/(\d+[\d,\.]*)\s+ocupaciones/);
   expect(m).toBeTruthy();
-  const count = parseInt((m![1] || '0').replace(/[\.,]/g, ''), 10);
+  const count = parseInt((m![1] || "0").replace(/[\.,]/g, ""), 10);
   expect(count).toBeGreaterThan(0);
 });
 
 test("card counts after filtering do not error", async ({ page }) => {
   await page.goto(baseURL + "/public/index.html");
-  await page.click('#btn-cards');
-  await page.waitForSelector('#cardsView:not(.hidden)');
-  const card = page.locator('.division-card').first();
+  await page.click("#btn-cards");
+  await page.waitForSelector("#cardsView:not(.hidden)");
+  const card = page.locator(".division-card").first();
   await expect(card).toBeVisible();
-  const hasFilter = await page.$('#filterFamily');
+  const hasFilter = await page.$("#filterFamily");
   if (hasFilter) {
-    const options = await page.$$eval('#filterFamily option', opts => opts.map(o => (o as HTMLOptionElement).value));
-    const val = options.find(v => v !== "");
+    const options = await page.$$eval("#filterFamily option", (opts) =>
+      opts.map((o) => (o as HTMLOptionElement).value)
+    );
+    const val = options.find((v) => v !== "");
     if (val) {
-      await page.selectOption('#filterFamily', val);
+      await page.selectOption("#filterFamily", val);
       await page.waitForTimeout(300);
       const txt = await card.textContent();
       const mm = txt?.match(/(\d+[\d,\.]*)\s+ocupaciones/);


### PR DESCRIPTION
## Summary
- Add .theme-neo CSS tokens and apply neobrutalist styles to header, tabs/buttons, cards, and D3 nodes.
- Add a Neo toggle button to enable/disable the theme at runtime.

## Test plan
- Run `npm run dev`, open /public/, click "Neo"; verify:
  - Header uses solid bar with 3px border
  - Tabs/buttons are square with 3px borders and clear active state
  - Cards use solid fills with thick borders; counts visible
  - Tree nodes have thicker strokes
  - A11y: focus rings visible; controls >=44px

💘 Generated with Crush